### PR TITLE
Better image compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 
 [[package]]
 name = "alpha-bleed"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "image",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpha-bleed"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]

--- a/src/alpha_bleed.rs
+++ b/src/alpha_bleed.rs
@@ -58,6 +58,8 @@ pub fn alpha_bleed(image: &mut RgbaImage, thickness: usize) {
                 visited[flat_index] = true;
                 pixel_queue.push_back((x, y));
             }
+
+            image.put_pixel(x, y, Rgba([0, 0, 0, 0]));
         }
     }
 


### PR DESCRIPTION
This PR converts the fully transparent pixels to black. By doing so the image encoding of the file is able to reduce file size by being able to more easily encode large swathes of pixels that are the same (large areas of pure transparent black).